### PR TITLE
Creating documents requires a JSON body

### DIFF
--- a/lib/pandadoc/api/document.rb
+++ b/lib/pandadoc/api/document.rb
@@ -70,7 +70,7 @@ module Pandadoc
 
         HTTParty.post("#{Pandadoc::Api::API_ROOT}/documents",
                       headers: { 'Authorization' => auth_header(token), 'Content-Type': 'application/json' },
-                      body: validated_params(params, validations))
+                      body: validated_params(params, validations).to_json)
       end
 
       def status(token, document_id)

--- a/spec/pandadoc/api/document_spec.rb
+++ b/spec/pandadoc/api/document_spec.rb
@@ -42,7 +42,7 @@ describe Pandadoc::Api::Document do
 
   describe 'create' do
     before :each do
-      stub_request(:post, "#{Pandadoc::Api::API_ROOT}/documents").to_return(status: 200)
+      stub_request(:post, "#{Pandadoc::Api::API_ROOT}/documents").to_return(status: 201)
     end
 
     after :each do
@@ -55,13 +55,11 @@ describe Pandadoc::Api::Document do
       expect(a_request(:post, "#{Pandadoc::Api::API_ROOT}/documents")).to have_been_made.once
     end
 
-    it 'passes the params' do
+    it 'passes the params as json' do
       params = { name: 'My Doc', template_uuid: '1234', recipients: ['a@a.com'] }
       subject.create('token', params)
 
-      expect(a_request(:post, "#{Pandadoc::Api::API_ROOT}/documents").with do |req|
-        req.body == 'name=My%20Doc&template_uuid=1234&recipients[]=a%40a.com'
-      end).to have_been_made
+      expect(WebMock).to have_requested(:post, "#{Pandadoc::Api::API_ROOT}/documents").with(body: params.to_json)
     end
 
     it 'sends authorization' do
@@ -76,7 +74,7 @@ describe Pandadoc::Api::Document do
 
     it 'returns results' do
       params = { name: 'My Doc', template_uuid: '1234', recipients: ['a@a.com'] }
-      expect(subject.create('token', params).code).to eq(200)
+      expect(subject.create('token', params).code).to eq(201)
     end
   end
 


### PR DESCRIPTION
Per the PandaDoc API documentation, sending the data for creating a
document should be done via JSON rather than form data.

* Also updates the stubbed response for creating a document to a 201 to
more closely represent the API.

* Use the `have_requested` matcher with `WebMock` to represent the
behavior a little more clearly.