### PR TITLE
Extract ParamsValidator class

### DIFF
--- a/lib/pandadoc/api.rb
+++ b/lib/pandadoc/api.rb
@@ -1,4 +1,5 @@
 require 'pandadoc/api/client'
+require 'pandadoc/api/params_validator'
 require 'pandadoc/api/version'
 require 'pandadoc/api/document'
 require 'pandadoc/api/template'

--- a/lib/pandadoc/api/document.rb
+++ b/lib/pandadoc/api/document.rb
@@ -1,29 +1,3 @@
-class RequiredParameterError < StandardError
-  attr_reader :parameter
-
-  def initialize(message, parameter)
-    # Call the parent's constructor to set the message
-    super(message)
-
-    # Store the action in an instance variable
-    @parameter = parameter
-  end
-end
-
-class ParameterTypeError < StandardError
-  attr_reader :received
-  attr_reader :requested
-
-  def initialize(message, received, requested)
-    # Call the parent's constructor to set the message
-    super(message)
-
-    # Store the action in an instance variable
-    @received = received
-    @requested = requested
-  end
-end
-
 module Pandadoc
   module Api
     class Document
@@ -103,28 +77,14 @@ module Pandadoc
         client.get "/documents/#{document_id}/download", token
       end
 
-      def validated_params(params, validations)
-        valid_keys = validations.keys
-        valid_params = params.keep_if { |key| valid_keys.include? key }
-
-        validations.each_pair do |key, validators|
-          if validators[:required] == true && valid_params[key].nil?
-            raise RequiredParameterError.new('Missing required parameter', key)
-          end
-
-          validators_type_array = validators[:type].is_a?(Array) ? validators[:type] : [validators[:type]]
-          if valid_params[key] && !validators_type_array.include?(valid_params[key].class)
-            raise ParameterTypeError.new("Invalid parameter type, received #{valid_params[key].class} requested #{validators[:type]}", valid_params[:key].class, validators[:type])
-          end
-        end
-
-        valid_params
-      end
-
       private
 
       def client
         @client ||= Pandadoc::Api::Client.new
+      end
+
+      def validated_params(params, validations)
+        Pandadoc::Api::ParamsValidator.validate(params, validations)
       end
     end
   end

--- a/lib/pandadoc/api/params_validator.rb
+++ b/lib/pandadoc/api/params_validator.rb
@@ -1,0 +1,49 @@
+module Pandadoc
+  module Api
+    class ParamsValidator
+      class RequiredParameterError < StandardError
+        attr_reader :parameter
+
+        def initialize(message, parameter)
+          # Call the parent's constructor to set the message
+          super(message)
+
+          # Store the action in an instance variable
+          @parameter = parameter
+        end
+      end
+
+      class ParameterTypeError < StandardError
+        attr_reader :received
+        attr_reader :requested
+
+        def initialize(message, received, requested)
+          # Call the parent's constructor to set the message
+          super(message)
+
+          # Store the action in an instance variable
+          @received = received
+          @requested = requested
+        end
+      end
+
+      def self.validate(params, validations)
+        valid_keys = validations.keys
+        valid_params = params.keep_if { |key| valid_keys.include? key }
+
+        validations.each_pair do |key, validators|
+          if validators[:required] == true && valid_params[key].nil?
+            raise RequiredParameterError.new('Missing required parameter', key)
+          end
+
+          validators_type_array = validators[:type].is_a?(Array) ? validators[:type] : [validators[:type]]
+          if valid_params[key] && !validators_type_array.include?(valid_params[key].class)
+            raise ParameterTypeError.new("Invalid parameter type, received #{valid_params[key].class} requested #{validators[:type]}", valid_params[:key].class, validators[:type])
+          end
+        end
+
+        valid_params
+      end
+    end
+  end
+end

--- a/lib/pandadoc/api/template.rb
+++ b/lib/pandadoc/api/template.rb
@@ -16,25 +16,11 @@ module Pandadoc
         client.get "/templates/#{template_id}/details", token
       end
 
-      def validated_params(params, validations)
-        valid_keys = validations.keys
-        valid_params = params.keep_if { |key| valid_keys.include? key }
-
-        validations.each_pair do |key, validators|
-          if validators[:required] == true && valid_params[key].nil?
-            raise RequiredParameterError.new('Missing required parameter', key)
-          end
-
-          validators_type_array = validators[:type].is_a?(Array) ? validators[:type] : [validators[:type]]
-          if valid_params[key] && !validators_type_array.include?(valid_params[key].class)
-            raise ParameterTypeError.new("Invalid parameter type, received #{valid_params[key].class} requested #{validators[:type]}", valid_params[:key].class, validators[:type])
-          end
-        end
-
-        valid_params
-      end
-
       private
+
+      def validated_params(params, validations)
+        Pandadoc::Api::ParamsValidator.validate(params, validations)
+      end
 
       def client
         @client ||= Pandadoc::Api::Client.new

--- a/pandadoc-api.gemspec
+++ b/pandadoc-api.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.58'
   spec.add_development_dependency 'webmock', '~> 3.4'
+  spec.add_development_dependency 'pry'
 end

--- a/spec/pandadoc/api/params_validator_spec.rb
+++ b/spec/pandadoc/api/params_validator_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Pandadoc::Api::ParamsValidator do
+  describe '.validate' do
+    describe 'basic behavior' do
+      it 'returns {}' do
+        expect(described_class.validate({}, {})).not_to be_nil
+      end
+    end
+
+    describe 'passes validations' do
+      describe 'invalid parameter' do
+        it 'returns only the valid params' do
+          params = { valid: '1', invalid: '2' }
+          validations = { valid: { required: false, type: String } }
+
+          expect(described_class.validate(params, validations)).to eq(valid: '1')
+        end
+      end
+    end
+
+    describe 'missing required' do
+      it 'raises a RequiredParameterError' do
+        params = { can_exist: '2' }
+        validations = { has_to_exist: { required: true, type: String }, can_exist: { required: false, type: String } }
+
+        expect do
+          described_class.validate(params, validations)
+        end.to raise_error(described_class::RequiredParameterError)
+      end
+    end
+
+    describe 'invalid type' do
+      it 'raises a ParameterTypeError' do
+        params = { string_type: 2 }
+        validations = { string_type: { required: false, type: String } }
+
+        expect do
+          described_class.validate(params, validations)
+        end.to raise_error(described_class::ParameterTypeError)
+      end
+    end
+  end
+end

--- a/spec/pandadoc/api/template_spec.rb
+++ b/spec/pandadoc/api/template_spec.rb
@@ -17,12 +17,13 @@ describe Pandadoc::Api::Template do
       expect(client_spy).to have_received(:get).with('/templates', token, {})
     end
 
-    it 'passes the params' do
+    it 'passes validated params' do
       params = { q: 'recipe' }
+      validated_params = stub_params_validator(params)
 
       subject.list(token, params)
 
-      expect(client_spy).to have_received(:get).with('/templates', token, params)
+      expect(client_spy).to have_received(:get).with('/templates', token, validated_params)
     end
 
     it 'returns results' do
@@ -44,44 +45,9 @@ describe Pandadoc::Api::Template do
     end
   end
 
-  describe 'validated_params' do
-    describe 'basic behavior' do
-      it 'returns {}' do
-        expect(subject.validated_params({}, {})).not_to be_nil
-      end
-    end
-
-    describe 'passes validations' do
-      describe 'invalid parameter' do
-        it 'returns only the valid params' do
-          params = { valid: '1', invalid: '2' }
-          validations = { valid: { required: false, type: String } }
-
-          expect(subject.validated_params(params, validations)).to eq(valid: '1')
-        end
-      end
-    end
-
-    describe 'missing required' do
-      it 'raises a RequiredParameterError' do
-        params = { can_exist: '2' }
-        validations = { has_to_exist: { required: true, type: String }, can_exist: { required: false, type: String } }
-
-        expect do
-          subject.validated_params(params, validations)
-        end.to raise_error(RequiredParameterError)
-      end
-    end
-
-    describe 'invalid type' do
-      it 'raises a ParameterTypeError' do
-        params = { string_type: 2 }
-        validations = { string_type: { required: false, type: String } }
-
-        expect do
-          subject.validated_params(params, validations)
-        end.to raise_error(ParameterTypeError)
-      end
+  def stub_params_validator(params)
+    double(:validated_params).tap do |validated_params|
+      allow(Pandadoc::Api::ParamsValidator).to receive(:validate).with(params, any_args).and_return(validated_params)
     end
   end
 end


### PR DESCRIPTION
We were previously duplicating the behavior of validating params within
both, the template and document classes. This extracts the
ParamsValidator to encapsulate this.